### PR TITLE
Refactor admin role ID validation in is_admins function

### DIFF
--- a/iam/src/utils/admin.py
+++ b/iam/src/utils/admin.py
@@ -13,10 +13,8 @@ def is_admins(roles: list[str]) -> bool:
     :return: bool
     """
     if not settings.has_system_admin_role_id() or not settings.has_admin_role_id():
-        logger.warning(
-            "System admin or admin role IDs are not set in settings. Attempting to set them."
-        )
-        set_admins_role_ids()
+        logger.error("Admin role IDs are not set. Denying access. Check lifespan initialization.")
+        return False
     return bool({settings.SYSTEM_ADMIN_ROLE_ID, settings.ADMIN_ROLE_ID} & set(roles))
 
 


### PR DESCRIPTION
- Updated logging to use error level when admin role IDs are not set, denying access.
- Removed previous warning and role ID setting logic for improved clarity and security.