### PR TITLE
Refactor datetime handling to use timezone-aware timestamps in servic…

### DIFF
--- a/iam/src/domains/service_versions/db/mongo/service_version.py
+++ b/iam/src/domains/service_versions/db/mongo/service_version.py
@@ -1,7 +1,7 @@
 """Database operations for service_versions collection."""
 
 from domains.service_versions.models import ServiceVersion
-from datetime import datetime
+from datetime import datetime, timezone
 
 DEFAULT_VERSION = "0.0.0"
 KEYCLOAK_KEY = "keycloak"
@@ -35,7 +35,7 @@ async def set_version(key: str, version: str) -> ServiceVersion:
     doc = await ServiceVersion.find_one({"service": key})
     if doc:
         doc.version = version
-        doc.updated_at = datetime.utcnow()
+        doc.updated_at = datetime.now(timezone.utc)
         await doc.save()
         return doc
     doc = ServiceVersion(service=key, version=version)

--- a/iam/src/domains/service_versions/models/service_version.py
+++ b/iam/src/domains/service_versions/models/service_version.py
@@ -1,5 +1,5 @@
 from pydantic import Field
-from datetime import datetime
+from datetime import datetime, timezone
 from beanie import Document
 from pymongo import IndexModel, ASCENDING
 
@@ -7,8 +7,8 @@ from pymongo import IndexModel, ASCENDING
 class ServiceVersion(Document):
     service: str = Field(..., description="Service identifier (e.g. keycloak)")
     version: str = Field(default="0.0.0", description="Current config version")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Creation timestamp")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Last update timestamp")
 
     class Settings:
         name = "service_versions"

--- a/iam/src/domains/users/db/mongo/user.py
+++ b/iam/src/domains/users/db/mongo/user.py
@@ -7,7 +7,7 @@ decoupling the service layer from MongoDB-specific implementations.
 from domains.users.models import User
 from typing import Optional, Union, List
 from bson import ObjectId
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 
@@ -97,8 +97,8 @@ async def create_user(
         last_name=last_name,
         email=email,
         roles=roles,
-        created_at=datetime.utcnow(),
-        updated_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
     return await user.insert()
 
@@ -124,7 +124,7 @@ async def update_user(user: User, **kwargs) -> User:
             setattr(user, field, value)
     
     # Update timestamp
-    user.updated_at = datetime.utcnow()
+    user.updated_at = datetime.now(timezone.utc)
     
     await user.save()
     return user

--- a/iam/src/domains/users/models/user.py
+++ b/iam/src/domains/users/models/user.py
@@ -1,5 +1,5 @@
 from pydantic import Field, EmailStr
-from datetime import datetime
+from datetime import datetime, timezone
 from beanie import Document
 from pymongo import IndexModel, ASCENDING, DESCENDING
 from typing import List, Optional
@@ -13,8 +13,8 @@ class User(Document):
     last_name: str = Field(..., description="Last name")
     email: EmailStr = Field(..., description="Email address")
     roles: List[str] = Field(..., description="List of role IDs")
-    created_at: datetime = Field(default_factory=datetime.utcnow, description="System creation timestamp")
-    updated_at: datetime = Field(default_factory=datetime.utcnow, description="Last update timestamp")
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="System creation timestamp")
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc), description="Last update timestamp")
 
     class Settings:
         name = "users"


### PR DESCRIPTION
…e and user models

- Updated `created_at` and `updated_at` fields in `ServiceVersion` and `User` models to use timezone-aware datetime.
- Modified database operations in `service_version.py` and `user.py` to reflect these changes, ensuring consistent timestamp handling across the application.